### PR TITLE
fix issue when having multiple layers who only differ in padding

### DIFF
--- a/NN_Deployment/Model_deployment.py
+++ b/NN_Deployment/Model_deployment.py
@@ -139,7 +139,7 @@ class Model_deployment():
                               dma_parallelization = dma_parallelization,
                               number_of_clusters = number_of_clusters)
             str_l = 'ch_in' + str(nodes_to_deploy.ch_in) + 'ch_out' + str(nodes_to_deploy.ch_out) + 'groups' + str(
-                nodes_to_deploy.group) + 'dim_image' + str(nodes_to_deploy.input_dim[1],) + 'stride' + str(nodes_to_deploy.strides) + 'kernel'+ str(
+                nodes_to_deploy.group) + 'dim_image' + str(nodes_to_deploy.input_dim[1],) + 'pads' + ''.join([str(x) for x in nodes_to_deploy.pads]) +'stride' + str(nodes_to_deploy.strides) + 'kernel'+ str(
                 nodes_to_deploy.kernel_shape[0]) + str(nodes_to_deploy.kernel_shape[1]) + 'BitIn' + str(BitIn) + 'BitOut' + str(BitOut) + 'BitW' + str(BitW)
             if '1D' in layer:
                 str_l += 'Dilation' + str(nodes_to_deploy.dilations)


### PR DESCRIPTION
If we have layers who have exactly the same hyperparameters except padding, DORY generates the same file for all layers, although they should all have different files. Adding the padding into str_l fixes the issue