### PR TITLE
Add conditional import for dory_examples

### DIFF
--- a/dory/__init__.py
+++ b/dory/__init__.py
@@ -1,2 +1,7 @@
+import warnings
 
-from . import dory_examples, Frontend_frameworks, Hardware_targets, Parsers, Utils
+from . import Frontend_frameworks, Hardware_targets, Parsers, Utils
+try:
+    from . import dory_examples
+except ImportError:
+    print("WARNING: Could not import dory_examples, is the dory_examples submodule initialized?")


### PR DESCRIPTION
Quick fix:
makes sure that dory can still be imported as a pip package,
even though the dory_examples submodule wasn't initialized.

Some comments:
* This is not PEP8 compliant (message is too long)
* Warning should probably be emitted by a proper warning/logger
  mechanism
  
 This is useful in cases where dory_examples is not necessary (e.g. in CI testing)