### PR TITLE
Use relative path for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "dory_examples"]
 	path = dory/dory_examples
-	url = git@github.com:pulp-platform/dory_examples
+	url = ../../pulp-platform/dory_examples
 [submodule "Hardware-targets/GAP8/Backend_Kernels/pulp-nn-mixed"]
 	path = dory/Hardware_targets/GAP8/Backend_Kernels/pulp-nn-mixed
-	url = git@github.com:pulp-platform/pulp-nn-mixed.git
+	url = ../../pulp-platform/pulp-nn-mixed.git
 [submodule "Hardware-targets/GAP8/Backend_Kernels/pulp-nn"]
 	path = dory/Hardware_targets/GAP8/Backend_Kernels/pulp-nn
-	url = git@github.com:pulp-platform/pulp-nn.git
+	url = ../../pulp-platform/pulp-nn.git
 [submodule "Hardware-targets/GAP8/Backend_Kernels/pulp-nn-1d"]
 	path = dory/Hardware_targets/GAP8/Backend_Kernels/pulp-nn-1d
-	url = git@github.com:pulp-platform/pulp-nn-1d.git
+	url = ../../pulp-platform/pulp-nn-1d.git
 [submodule "Hardware-targets/Diana/Backend_Kernels/dory-hal"]
 	path = dory/Hardware_targets/Diana/Backend_Kernels/dory-hal
-	url = git@github.com:ABurrello/dory-hal.git
+	url = ../../ABurrello/dory-hal.git

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Execute the following commands to clone DORY and pulp-nn backend:
 ```
 git clone https://github.com/pulp-platform/dory
 cd dory
-git submodule update --init --recursive
+git submodule update --remote --init dory/dory_examples
+git submodule update --remote --init dory/Hardware_targets/GAP8/Backend_Kernels/pulp-nn
+git submodule update --remote --init dory/Hardware_targets/GAP8/Backend_Kernels/pulp-nn-mixed
 python3 -m pip install -e .
 ```
 


### PR DESCRIPTION
This commit adds a relative path to all git submodules.
This makes sure that if a user copies over HTTPS the submodules
are also copied over HTTPS.
If the user copies over SSH the submodules are downloaded over SSH.
HTTPS pulls for submodules are useful in CI environments.

as per https://stackoverflow.com/questions/40841882/automatically-access-git-submodules-via-ssh-or-https

Note that this commit also has changed the README.md.
In my testing the `pulp-nn-1d` repository is not public, so
initializing the submodules with the `--recursive` flag results in
an error.
In my case this also meant that the public submodules were left in
a weird state. (submodules were initialized but all files were
deleted, so you would have to `git restore` each submodule).
Initializing every submodule separately should solve this issue.