### PR TITLE
Added support for PULP-SDK for L2-only applications

### DIFF
--- a/dory/Hardware_targets/GAP8/GAP8_board_L2/C_Parser.py
+++ b/dory/Hardware_targets/GAP8/GAP8_board_L2/C_Parser.py
@@ -138,6 +138,7 @@ class C_Parser(Parser_HW_to_C):
         tk['weights_vectors'] = weights_vectors
         tk['weights_dimensions'] = weights_dimensions
         tk['DORY_HW_graph'] = self.HWgraph
+        tk['sdk'] = node.HW_description["software development kit"]["name"]
         root = os.path.dirname(__file__)
         tmpl = Template(filename=os.path.join(root, "Templates/weights_h_template.h"))
         s = tmpl.render(**tk)
@@ -165,6 +166,7 @@ class C_Parser(Parser_HW_to_C):
         tk = OrderedDict([])
         tk['input_values'] = input_values
         tk['dimension'] = len(x_in)
+        tk['sdk'] = self.HW_description["software development kit"]["name"]
         root = os.path.dirname(__file__)
         tmpl = Template(filename=os.path.join(root, "Templates/input_h_template.h"))
         s = tmpl.render(**tk)

--- a/dory/Hardware_targets/GAP8/GAP8_board_L2/Templates/input_h_template.h
+++ b/dory/Hardware_targets/GAP8/GAP8_board_L2/Templates/input_h_template.h
@@ -17,5 +17,9 @@
  * limitations under the License. 
  */
 
+% if sdk == 'gap_sdk':
 L2_DATA uint8_t L2_input_h[${dimension}] = {
+% elif sdk == 'pulp-sdk':
+PI_L2 uint8_t L2_input_h[${dimension}] = {
+% endif
 ${input_values}};

--- a/dory/Hardware_targets/GAP8/GAP8_board_L2/Templates/weights_h_template.h
+++ b/dory/Hardware_targets/GAP8/GAP8_board_L2/Templates/weights_h_template.h
@@ -17,12 +17,18 @@
  * limitations under the License. 
  */
 
-#include <hal/pulp.h>
+% if sdk == 'gap_sdk':
 #include "pulp.h"
+% endif
+#include <hal/pulp.h>
 
 % for i in range(len(weights_vectors)):
 % if weights_dimensions[i] > 0:
+% if sdk == 'gap_sdk':
 L2_DATA uint8_t Weights_${DORY_HW_graph[i].name}[${weights_dimensions[i]}] = {
+% elif sdk == 'pulp-sdk':
+PI_L2 uint8_t Weights_${DORY_HW_graph[i].name}[${weights_dimensions[i]}] = {
+% endif
 ${weights_vectors[i]}};
 % endif
 % endfor


### PR DESCRIPTION
The L2-only Dory tiler now supports deployment using PULP-SDK. It was tested in GVSOC and FPGA (ZCU102).