### PR TITLE
Remove performance counters out of conv2d template for Diana_TVM

### DIFF
--- a/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -37,10 +37,6 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
   unsigned int l1_y       = l1_x + ${int(l1_y_offset/32)*32+32};
   unsigned int l1_weights = 0x0;
 
-  // perf measurement begin
-  volatile rt_perf_t *perf;
-  perf = rt_alloc(RT_ALLOC_L2_CL_DATA, sizeof(rt_perf_t));
-
   /////////////////////
   // DMA declaration //
   /////////////////////
@@ -90,13 +86,6 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
 % endif
   // tile loop nest
   for(iter=0; iter < total_tiles; iter++) {
-
-    int perf_cyc, perf_cyc1, perf_cyc2;
-    rt_perf_init(perf);
-    rt_perf_conf(perf, (1<<RT_PERF_CYCLES));
-    rt_perf_stop(perf);
-    rt_perf_start(perf);
-
 
     // check if last in any dimension
     x_tile_size_nif = (_i_nif+1   == ${tile_dim_nif}) ? ${x_tile_size_nif_last} : ${x_tile_size_nif};
@@ -180,16 +169,6 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
     kernel.stride = ${stride};
     kernel.ox = (int) y_tile_size_w / kernel.ox_unroll;
 % endif
-    rt_perf_stop(perf);
-    rt_perf_save(perf);
-    perf_cyc = rt_perf_get(perf, RT_PERF_CYCLES);
-    rt_perf_reset(perf);
-
-    rt_perf_init(perf);
-    rt_perf_conf(perf, (1<<RT_PERF_CYCLES));
-    rt_perf_stop(perf);
-    rt_perf_start(perf);
-
     int pad_offset_h=0, pad_offset_w=0;
     if(_i_h > 0)
       pad_offset_h = ${padding_top};
@@ -205,16 +184,6 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
     analog_conv_2d(l2_x_tile, l1_x, Weights_${func_name}, l2_BN, l1_weights, l1_y, &kernel);
     dory_cores_barrier_analog();
 % endif
-
-    rt_perf_stop(perf);
-    rt_perf_save(perf);
-    perf_cyc1 = rt_perf_get(perf, RT_PERF_CYCLES);
-    rt_perf_reset(perf);
-
-    rt_perf_init(perf);
-    rt_perf_conf(perf, (1<<RT_PERF_CYCLES));
-    rt_perf_stop(perf);
-    rt_perf_start(perf);
 
     _i_nof_pre = _i_nof;
     _i_nif_pre = _i_nif;
@@ -257,11 +226,6 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
     dory_dma_memcpy_async_analog(DMA_copy_y); 
     dory_dma_barrier_analog(DMA_copy_y);
 % endif
-    
-    rt_perf_stop(perf);
-    rt_perf_save(perf);
-    perf_cyc2 = rt_perf_get(perf, RT_PERF_CYCLES);
-    rt_perf_reset(perf);
   }
 
 


### PR DESCRIPTION
This pull request removes the performance counters inserted by Dory for the Diana_TVM backend.
Removing them is necessary to prevent them interfering with higher-level added performance counters.

Thanks!