### PR TITLE
Patch template of analog Conv2D for Diana TVM backend

### DIFF
--- a/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -36,7 +36,9 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
   //////////////////////////////////////////////////////////////////////////
   // arguments assigning: keeping same interface between L2 and L3 memory //
   //////////////////////////////////////////////////////////////////////////
-
+% if W_data_size_byte == 2:
+  unsigned int l2_BN	  = Weights_${func_name} + ${int((64 if nif < 64 else nif) * (128 if nof < 128 else nof) * fs1 * fs2 * W_data_size_byte / 8)};
+% endif
 % if int(func_name[-1]) % 2 == 0 or node.skip_L2_L1 == False:
   unsigned int l1_x       = 0x0;
 % if W_data_size_byte == 2:


### PR DESCRIPTION
This commit fixes the setting of the l2_BN (it was missing) parameter for the Diana TVM backend.
It compiles, but still requires functional testing.

@ABurrello can you have a look if this is correct and help me later with testing? Thanks!