### PR TITLE
Georgr/prefix net

### DIFF
--- a/dory/Frontend_frameworks/NEMO/Parser.py
+++ b/dory/Frontend_frameworks/NEMO/Parser.py
@@ -34,7 +34,7 @@ file_path = "/".join(os.path.realpath(__file__).split("/")[:-1])
 class onnx_manager(Parser_ONNX_to_DORY):
     # Used to manage the ONNX files. By now, supported Convolutions (PW and DW), Pooling, Fully Connected and Relu.
 
-    def __init__(self, onnx, config_file):
+    def __init__(self, onnx, config_file, net_prefix=""):
         layers_accepted = ['Conv', 'Pad', 'Mul', 'Add', 'Div', 'Constant', 'AveragePool', 'GlobalAveragePool', 'MaxPool', 'Cast', 'Clip', 'Floor', 'Flatten', 'Gemm', 'MatMul', 'Shape', 'Gather', 'Unsqueeze', 'Concat', 'Reshape', 'Sigmoid', 'LogSoftmax']
         layers_neglected = ['Cast', 'Floor', 'Flatten', 'Shape', 'Gather', 'Unsqueeze', 'Concat', 'Reshape', 'Sigmoid', 'LogSoftmax']
         layers_to_node = ['AveragePool', 'MaxPool', 'Conv', 'Gemm', 'MatMul', 'GlobalAveragePool']
@@ -45,7 +45,7 @@ class onnx_manager(Parser_ONNX_to_DORY):
             self.n_test_inputs = config_file["n_inputs"]
         except KeyError:
             self.n_test_inputs = 1
-        super().__init__(onnx, rules, layers_accepted, layers_neglected, layers_to_node)
+        super().__init__(onnx, rules, layers_accepted, layers_neglected, layers_to_node, net_prefix)
 
     def frontend_mapping_to_DORY_nodes(self):
         print("\nNEMO Frontend: Matching patterns from generated ONNX to DORY.")

--- a/dory/Frontend_frameworks/Quantlab/Parser.py
+++ b/dory/Frontend_frameworks/Quantlab/Parser.py
@@ -35,7 +35,7 @@ file_path = "/".join(os.path.realpath(__file__).split("/")[:-1])
 class onnx_manager(Parser_ONNX_to_DORY):
     # Used to manage the ONNX files. By now, supported Convolutions (PW and DW), Pooling, Fully Connected and Relu.
 
-    def __init__(self, onnx, config_file):
+    def __init__(self, onnx, config_file, net_prefix=""):
         layers_accepted = ['Conv', 'Pad', 'Mul', 'Add', 'Div', 'Constant', 'AveragePool', 'GlobalAveragePool', 'MaxPool', 'Cast', 'Clip', 'Floor', 'Flatten', 'Gemm', 'MatMul', 'Shape', 'Gather', 'Unsqueeze', 'Squeeze', 'Concat', 'Reshape', 'Sigmoid', 'LogSoftmax']
         layers_neglected = ['Cast', 'Floor', 'Flatten', 'Shape', 'Gather', 'Unsqueeze', 'Concat', 'Reshape', 'Sigmoid', 'LogSoftmax', 'Squeeze']
         layers_to_node = ['AveragePool', 'MaxPool', 'Conv', 'Gemm', 'MatMul', 'GlobalAveragePool']
@@ -53,7 +53,7 @@ class onnx_manager(Parser_ONNX_to_DORY):
             self.n_test_inputs = config_file["n_inputs"]
         except KeyError:
             self.n_test_inputs = 1
-        super().__init__(onnx, rules, layers_accepted, layers_neglected, layers_to_node)
+        super().__init__(onnx, rules, layers_accepted, layers_neglected, layers_to_node, net_prefix)
 
     def frontend_mapping_to_DORY_nodes(self):
         print("\nQuantlab Frontend: Matching patterns from generated ONNX to DORY.")

--- a/dory/Hardware_targets/PULP/Common/C_Parser.py
+++ b/dory/Hardware_targets/PULP/Common/C_Parser.py
@@ -23,6 +23,7 @@ import numpy as np
 # DORY modules
 from dory.Parsers.Parser_HW_to_C import Parser_HW_to_C
 import dory.Utils.Templates_writer.Layer2D_template_writer as Layer2D_writer
+import dory.Utils.Templates_writer.Makefile_template_writer as Makefile_writer
 
 
 
@@ -117,7 +118,7 @@ class C_Parser_PULP(Parser_HW_to_C):
         n_memory_levels = self.HW_description['memory']['levels']
         for i, node in enumerate(self.HWgraph):
             self.copy_backend_files(node)
-            
+
             if n_memory_levels > 2 and (node.L3_input != 0 or (node.tiling_dimensions["L3"]["output_dimensions"] != node.tiling_dimensions["L2"]["output_dimensions"]) or (node.tiling_dimensions["L3"]["weights_dimensions"] != node.tiling_dimensions["L2"]["weights_dimensions"])):
                 Layer2D_writer.print_template_layer_L3(node, tmpl_dir, out_dir)
                 if node.tiling_dimensions["L3"]["input_dimensions"][1] > node.tiling_dimensions["L2"]["input_dimensions"][1]:
@@ -148,5 +149,17 @@ class C_Parser_PULP(Parser_HW_to_C):
                 if node.tiling_dimensions["L2"]["input_dimensions"][1] == node.tiling_dimensions["L1"]["input_dimensions"][1]:
                     node.tiling_dimensions["L1"]["output_dimensions"][1] = int((node.tiling_dimensions["L1"]["input_dimensions"][1] + (node.pads[0] + node.pads[2]) - node.kernel_shape[0] + node.strides[0]) / node.strides[0])
                 Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
+
+    def mapping_makefile(self):
+        super(C_Parser_PULP, self).mapping_makefile()
+        # also print the "vars.mk"
+        prefix = self.HWgraph[0].prefix
+        Makefile_writer.print_template_Makefile(
+            self.HWgraph,
+            self.HW_description,
+            prefix+"vars.mk",
+            self.app_directory,
+            template_location_rel="Templates/vars.mk_template")
+
 
 

--- a/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
@@ -45,6 +45,9 @@ APP_CFLAGS += -DFLASH_TYPE=$(FLASH_TYPE) -DUSE_$(FLASH_TYPE) -DUSE_$(RAM_TYPE)
 % if blocking_dma:
 APP_CFLAGS += -DALWAYS_BLOCK_DMA_TRANSFERS
 % endif
+% if single_core_dma:
+APP_CFLAGS += -DSINGLE_CORE_DMA
+% endif
 
 include ${prefix}vars.mk
 

--- a/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
@@ -45,23 +45,7 @@ APP_CFLAGS += -DFLASH_TYPE=$(FLASH_TYPE) -DUSE_$(FLASH_TYPE) -DUSE_$(RAM_TYPE)
 % if blocking_dma:
 APP_CFLAGS += -DALWAYS_BLOCK_DMA_TRANSFERS
 % endif
-% if do_flash:
-% for layer in layers_w:
-FLASH_FILES += hex/${layer}
-% endfor
-% if n_inputs > 1:
-% for n_in in range(n_inputs):
-FLASH_FILES += hex/${prefix}inputs_${n_in}.hex
-% endfor
-% else:
-FLASH_FILES += hex/${prefix}inputs.hex
-% endif
 
-READFS_FILES := $(FLASH_FILES)
-% endif
-% if sdk == 'gap_sdk':
-APP_CFLAGS += -DFS_READ_FS
-% endif
-#PLPBRIDGE_FLAGS += -f
+include ${prefix}vars.mk
 
 include $(RULES_DIR)/pmsis_rules.mk

--- a/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/Makefile.t
@@ -51,10 +51,10 @@ FLASH_FILES += hex/${layer}
 % endfor
 % if n_inputs > 1:
 % for n_in in range(n_inputs):
-FLASH_FILES += hex/inputs_${n_in}.hex
+FLASH_FILES += hex/${prefix}inputs_${n_in}.hex
 % endfor
 % else:
-FLASH_FILES += hex/inputs.hex
+FLASH_FILES += hex/${prefix}inputs.hex
 % endif
 
 READFS_FILES := $(FLASH_FILES)

--- a/dory/Hardware_targets/PULP/Common/Templates/main.c.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/main.c.t
@@ -22,11 +22,11 @@ n_inputs = DORY_HW_graph[0].n_test_inputs
 single_input = n_inputs==1
 %>\
 % if not l3_supported:
-#include "input.h"
+#include "${prefix}input.h"
 % else:
 #include "mem.h"
 % endif
-#include "network.h"
+#include "${prefix}network.h"
 
 #include "pmsis.h"
 
@@ -59,7 +59,7 @@ int main () {
 */
 % if l3_supported:
   mem_init();
-  network_initialize();
+  ${prefix}network_initialize();
   % endif
   /*
     Allocating space for input
@@ -77,25 +77,22 @@ int main () {
 % if not single_input:
   for (int exec = 0; exec < ${n_inputs}; exec++) {
     % if l3_supported:
-  load_file_to_ram(ram_input, Input_names[exec]);
+      load_file_to_ram(ram_input, ${prefix}Input_names[exec]);
     % endif
 % elif l3_supported:
-
-  load_file_to_ram(ram_input, "inputs.hex");
+      load_file_to_ram(ram_input, "${prefix}inputs.hex");
 % endif
-
   % if l3_supported:
-  ram_read(l2_buffer, ram_input, l2_input_size);
+      ram_read(l2_buffer, ram_input, l2_input_size);
   % endif
-
-      network_run(l2_buffer, ${l2_buffer_size}, l2_buffer, ${"0" if single_input else "exec"}${f", L2_input_h{' + exec * l2_input_size' if not single_input else ''}" if not l3_supported else ""});
+      ${prefix}network_run(l2_buffer, ${l2_buffer_size}, l2_buffer, ${"0" if single_input else "exec"}${f", {prefix}L2_input_h{' + exec * l2_input_size' if not single_input else ''}" if not l3_supported else ""});
 
   % if not single_input:
   }
   % endif
   % if l3_supported:
   ram_free(ram_input, input_size);
-  network_terminate();
+  ${prefix}network_terminate();
   % endif
   pi_l2_free(l2_buffer, ${l2_buffer_size});
 }

--- a/dory/Hardware_targets/PULP/Common/Templates/network.c.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.c.t
@@ -377,7 +377,9 @@ void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final
     dir = !dir;
   }
 
-  memcpy(L2_output, l2_final_output, activations_out_size[${len(DORY_HW_graph)-1}]);
+  //memcpy(L2_output, l2_final_output, activations_out_size[${len(DORY_HW_graph)-1}]); // BUGGY!
+  for (int i=0; i<activations_out_size[${len(DORY_HW_graph)-1}]; i++)
+    *((uint8_t*)(l2_final_output+i)) = *((uint8_t*)(L2_output+i));
 
 /* ---------------------------------- */
 /* --------- SECTION 2 END ---------- */

--- a/dory/Hardware_targets/PULP/Common/Templates/network.c.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.c.t
@@ -301,7 +301,7 @@ void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final
         bypass_dimension = activations_out_size[i];
       }
 
-    if (i > 0 && branch_output[i-1]==0)
+    if (i > 0 && branch_output[i-1] == 0 && branch_change[i-1] == 0)
       dfree(activations_size[i], dir);
 % endif
     // Residual connections

--- a/dory/Hardware_targets/PULP/Common/Templates/network.h.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.h.t
@@ -17,8 +17,8 @@
  * limitations under the License. 
  */
 
-#ifndef __NETWORK_H__
-#define __NETWORK_H__
+#ifndef __${prefix.upper()}NETWORK_H__
+#define __${prefix.upper()}NETWORK_H__
 
 % if sdk == 'gap_sdk':
 #include "pulp.h"
@@ -96,7 +96,7 @@ static int allocate_layer[${len(DORY_HW_graph)}] = {\
 static char *Weights_name[${len(DORY_HW_graph)}] = {\
 % for i in range(len(DORY_HW_graph)):
 % if 'Conv' in DORY_HW_graph[i].name or 'FullyConnected' in DORY_HW_graph[i].name:
-Weights_${DORY_HW_graph[i].name}${'' if loop.last else ', '}\
+Weights_${DORY_HW_graph[i].prefixed_name}${'' if loop.last else ', '}\
 % else:
 "None"${'' if loop.last else ', '}\
 % endif

--- a/dory/Hardware_targets/PULP/Common/Templates/network.h.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.h.t
@@ -28,60 +28,39 @@
    single_input = n_inputs==1
 %>\
 % if not l3_supported:
-#include "weights_definition.h"
+#include "${prefix}weights_definition.h"
 % endif
 #include <stddef.h>
 
-#define PAD_TOP    (1 << 3)
-#define PAD_RIGHT  (1 << 2)
-#define PAD_BOTTOM (1 << 1)
-#define PAD_LEFT   (1 << 0)
-#define NO_PAD     (0)
-
-typedef struct {
-    unsigned int L3_input;
-    unsigned int L3_output;
-    unsigned int L3_after_weights;
-    unsigned int L2_input;
-    unsigned int bypass;
-    unsigned int L2_output;
-    unsigned int L2_weights;
-    unsigned int L1_buffer;
-    unsigned int ram;
-    unsigned int out_mult;
-    unsigned int out_shift;
-    unsigned int layer_id;
-} layer_args_t;
 
 % if l3_supported:
-void network_terminate();
-void network_initialize();
+void ${prefix}network_terminate();
+void ${prefix}network_initialize();
 % endif
-void network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec${", void *L2_input_h" if not l3_supported else ""});
-void execute_layer_fork(void *arg);
-void execute_layer(void *arg);
+void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec${", void *L2_input_h" if not l3_supported else ""});
+void ${prefix}execute_layer_fork(void *arg);
 
 % if l3_supported and not single_input:
-static char * Input_names[${n_inputs}] = {\
+static char * ${prefix}Input_names[${n_inputs}] = { \
   % for n in range(n_inputs-1):
-  "${f"inputs_{n}.hex"}",
+  "${f"{prefix}inputs_{n}.hex"}",
   % endfor
-  "${f"inputs_{n_inputs-1}.hex"}"
+  "${f"{prefix}inputs_{n_inputs-1}.hex"}"
 };
 % endif
 
 #ifdef DEFINE_CONSTANTS
 % if l3_supported:
 // allocation of buffers with parameters needed by the network execution
-const char * L3_weights_files[] = {
+static const char * L3_weights_files[] = {
   ${files_list}
 };
-int L3_weights_size[${weights_number}];
+static int L3_weights_size[${weights_number}];
 static int layers_pointers[${len(DORY_HW_graph)}];
 % endif
 static char * Layers_name[${len(DORY_HW_graph)}] = {\
 % for node in DORY_HW_graph:
-"${node.name}"${'' if loop.last else ', '}\
+"${node.prefixed_name}"${'' if loop.last else ', '}\
 % endfor
 };
 % if l3_supported:

--- a/dory/Hardware_targets/PULP/Common/Templates/network.h.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.h.t
@@ -37,6 +37,7 @@
 void ${prefix}network_terminate();
 void ${prefix}network_initialize();
 % endif
+void ${prefix}network_run_cluster(void * args);
 void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec${", void *L2_input_h" if not l3_supported else ""});
 void ${prefix}execute_layer_fork(void *arg);
 

--- a/dory/Hardware_targets/PULP/Common/Templates/vars.mk.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/vars.mk.t
@@ -1,0 +1,18 @@
+% if do_flash:
+% for layer in layers_w:
+FLASH_FILES += hex/${layer}
+% endfor
+% if n_inputs > 1:
+% for n_in in range(n_inputs):
+FLASH_FILES += hex/${prefix}inputs_${n_in}.hex
+% endfor
+% else:
+FLASH_FILES += hex/${prefix}inputs.hex
+% endif
+
+READFS_FILES := $(FLASH_FILES)
+% endif
+% if sdk == 'gap_sdk':
+APP_CFLAGS += -DFS_READ_FS
+% endif
+#PLPBRIDGE_FLAGS += -f

--- a/dory/Hardware_targets/PULP/Common/Tiler/tiler_conv2d.py
+++ b/dory/Hardware_targets/PULP/Common/Tiler/tiler_conv2d.py
@@ -127,7 +127,7 @@ class Tiler_Conv2D_PULP():
             # size constraint
             input_tile_dimension  = db_x * in_ch * tile_h_in * inp_dim[1] * self.HW_node.input_activation_bits // 8
             output_tile_dimension = db_O * out_ch * tile_h_out * out_dim[1] * self.HW_node.output_activation_bits // 8
-            weight_tile_dimension = db_W * tile_n_out * int(in_ch / g) * np.prod(ks) * self.HW_node.weight_bits // 8
+            weight_tile_dimension = db_W * tile_n_out * (int(in_ch / g) * np.prod(ks) * self.HW_node.weight_bits // 8 + self.HW_node.bias_bits // 8 * int(self.HW_node.bias_memory != 0))
             constants = 0
             for name in self.HW_node.constant_names:
                 if name in ["l","k"]:
@@ -138,7 +138,6 @@ class Tiler_Conv2D_PULP():
                 constants_tile_dimension = 0
             constraint_all = input_tile_dimension + output_tile_dimension + weight_tile_dimension + constants_tile_dimension
             solver.Add(constraint_all <= L2_memory)
-                 
 
             # geometrical constraint
             if db_x == 2 and db_O == 2:   

--- a/dory/Hardware_targets/PULP/Common/Tiler/tiler_conv2d.py
+++ b/dory/Hardware_targets/PULP/Common/Tiler/tiler_conv2d.py
@@ -247,7 +247,8 @@ class Tiler_Conv2D_PULP():
                  weight_full_prec_dim = 0
         if 'FullyConnected' in self.HW_node.name:
             im2col_dim = 0
-
+        
+        
         in_mem = self.HW_node.tiling_dimensions["L2"]["input_activation_memory"]
         out_mem = self.HW_node.tiling_dimensions["L2"]["output_activation_memory"]
         h_in   = self.HW_node.tiling_dimensions["L2"]["input_dimensions"][1]
@@ -288,13 +289,17 @@ class Tiler_Conv2D_PULP():
         ###############################################
         ##### GEOMETRICAL CONSTRAINTS #################
         ###############################################
+        
         if g == 1 or (inp_dim[0] > 32 and inp_dim[1] > 32):
             solver.Add(0 == (tile_h_in - ks[0]) % s[0])
         if g > 1:
             solver.Add(tile_n_in == tile_n_out)
         if g == 1:
-            solver.Add(tile_h_out * s[0] == (tile_h_in - (ks[0] - 1) + (s[0] - 1)))
-            solver.Add(tile_w_out * s[1] == (tile_w_in - (ks[1] - 1) + (s[1] - 1)))
+            # if a tile dimension is equal to the total input dimension in a
+            # direction, padding must be counted as well. Otherwise we can
+            # simply calculate "too few" outputs in one tiling iteration (???) 
+            solver.Add(tile_h_out * s[0] == (tile_h_in - (ks[0] - 1) + (s[0] - 1) + (p[0] + p[2]) * (tile_h_in == inp_dim[0])))
+            solver.Add(tile_w_out * s[1] == (tile_w_in - (ks[1] - 1) + (s[1] - 1) + (p[1] + p[3]) * (tile_w_in == inp_dim[1])))
 
         ###############################################
         ##### CONSTRAINTS FOR BACKEND LIMITS ##########
@@ -318,14 +323,14 @@ class Tiler_Conv2D_PULP():
         ##### CONSTRAINTS FOR DIMENSION ###############
         ###############################################
 
-        input_tile_dimension  = db * tile_n_in * tile_h_in * tile_w_in * self.HW_node.input_activation_bits // 8
-        output_tile_dimension = db * tile_n_out * tile_h_out * tile_w_out * self.HW_node.output_activation_bits // 8
+        input_tile_dimension  = db * (tile_n_in * tile_h_in * tile_w_in * self.HW_node.input_activation_bits) // 8
+        output_tile_dimension = db * (tile_n_out * tile_h_out * tile_w_out * self.HW_node.output_activation_bits) // 8
         if g == 1:
             weight_tile_dimension = db * tile_n_in * tile_n_out * np.prod(ks) * self.HW_node.weight_bits // 8
             im2col_dimension = 2 * 8 * np.prod(ks) * tile_n_in
             weight_full_prec_dimension = 0
         else:
-            weight_tile_dimension = db * tile_n_in * np.prod(ks) * self.HW_node.weight_bits // 8
+            weight_tile_dimension = (db * tile_n_in * np.prod(ks) * self.HW_node.weight_bits) // 8
             im2col_dimension = 8 * (ks[0] * (tile_n_in + p[0] + p[2]) + ks[0]) * int( 8 / min(self.HW_node.input_activation_bits, self.HW_node.output_activation_bits, self.HW_node.weight_bits))
             weight_full_prec_dimension = 0
             if self.HW_node.weight_bits != 8:
@@ -342,7 +347,7 @@ class Tiler_Conv2D_PULP():
         else:
             constants_tile_dimension = 0
 
-        constraint_all = self.HW_node.tiling_dimensions["L2"]["bias_memory"] + input_tile_dimension + output_tile_dimension + weight_tile_dimension + constants_tile_dimension + im2col_dimension + weight_full_prec_dimension + 20 
+        constraint_all = self.HW_node.tiling_dimensions["L2"]["bias_memory"] + input_tile_dimension + output_tile_dimension + weight_tile_dimension + constants_tile_dimension + im2col_dimension + weight_full_prec_dimension + 40 
 
         solver.Add(constraint_all <= L1_memory)
 
@@ -402,6 +407,7 @@ class Tiler_Conv2D_PULP():
         # Add the objective.
         collector.AddObjective(obj_expr)
         solver.Solve(decision_builder, [objective, collector])
+        
         if collector.SolutionCount() > 0:
             best_solution = collector.SolutionCount() - 1
             tile_n_in = collector.Value(best_solution, tile_n_in)
@@ -410,6 +416,7 @@ class Tiler_Conv2D_PULP():
             tile_h_out = collector.Value(best_solution, tile_h_out)
             tile_w_in = collector.Value(best_solution, tile_w_in)
             tile_w_out = collector.Value(best_solution, tile_w_out)
+
             if tile_h_in >= inp_dim[0]:
                 tile_h_in = inp_dim[0]
                 tile_h_out = int((tile_h_in -(ks[0] - 1) + (p[0] + p[2]) + (s[0] - 1))/s[0])

--- a/dory/Hardware_targets/PULP/Common/Tiler/tiler_pool2d.py
+++ b/dory/Hardware_targets/PULP/Common/Tiler/tiler_pool2d.py
@@ -58,8 +58,6 @@ class Tiler_Pool2D_PULP():
         s = self.HW_node.strides
         p = self.HW_node.pads
 
-        conv_overlap_h = 2 * (ks[0] // 2) + ks[0] % 2 - 1 - (s[0] - 1)
-
         if self.previous_HW_node.tiling_dimensions["L3"]["output_dimensions"] != self.previous_HW_node.tiling_dimensions["L3"]["output_dimensions"]:
             input_L3 = 1
             input_dim_constraint = self.previous_HW_node.tiling_dimensions["L2"]["output_activation_memory"]

--- a/dory/Hardware_targets/PULP/Common/Utils/directional_allocator.h
+++ b/dory/Hardware_targets/PULP/Common/Utils/directional_allocator.h
@@ -39,6 +39,9 @@ static void *directional_mem_end = NULL;
 static void directional_allocator_init(void *begin, int size) {
     directional_mem_begin = begin;
     directional_mem_end = begin + size;
+#if DBG_DIRALLOC
+    printf("Directional allocator init:\n   Set directional_mem_begin to 0x%X\n   Set directional_mem_end to 0x%X", directional_mem_begin, directional_mem_end);
+#endif
 }
 
 static void *dmalloc(int size, int direction) {
@@ -51,6 +54,9 @@ static void *dmalloc(int size, int direction) {
             directional_mem_end -= size;
             retval = directional_mem_end;
         }
+#if DBG_DIRALLOC
+        printf("Direcional allocator:\n   Allocated %d bytes in direction %d\n   Begin now at 0x%X\n   End now at 0x%X\n", size, direction, directional_mem_begin, directional_mem_end);
+#endif
     }
     return retval;
 }
@@ -60,6 +66,9 @@ static void dfree(int size, int direction) {
         directional_mem_begin -= size;
     else
         directional_mem_end += size;
+#if DBG_DIRALLOC
+    printf("Directional allocator:\n   Freed %d bytes in direction %d\n   Begin now at 0x%X\n   End now at 0x%X\n", size, direction, directional_mem_begin, directional_mem_end);
+#endif
 }
 
 #endif

--- a/dory/Hardware_targets/PULP/Common/Utils/mem.c
+++ b/dory/Hardware_targets/PULP/Common/Utils/mem.c
@@ -43,6 +43,7 @@ static struct pi_readfs_conf fs_conf;
 static struct pi_device ram;
 static ram_conf_t ram_conf;
 
+
 void mem_init() {
   flash_conf_init(&flash_conf);
   pi_open_from_conf(&flash, &flash_conf);
@@ -88,6 +89,32 @@ void ram_read(void *dest, void *src, const size_t size) {
 
 void ram_write(void *dest, void *src, const size_t size) {
   pi_ram_write(&ram, dest, src, size);
+}
+
+void *cl_ram_malloc(size_t size) {
+  int addr;
+  pi_cl_ram_req_t req;
+  pi_cl_ram_alloc(&ram, size, &req);
+  pi_cl_ram_alloc_wait(&req, &addr);
+  return (void *) addr;
+}
+
+void cl_ram_free(void *ptr, size_t size) {
+  pi_cl_ram_req_t req;
+  pi_cl_ram_free(&ram, ptr, size, &req);
+  pi_cl_ram_free_wait(&req);
+}
+
+void cl_ram_read(void *dest, void *src, const size_t size) {
+  pi_cl_ram_req_t req;
+  pi_cl_ram_read(&ram, src, dest, size, &req);
+  pi_cl_ram_read_wait(&req);
+}
+
+void cl_ram_write(void *dest, void *src, const size_t size) {
+  pi_cl_ram_req_t req;
+  pi_cl_ram_write(&ram, dest, src, size, &req);
+  pi_cl_ram_write_wait(&req);
 }
 
 size_t load_file_to_ram(const void *dest, const char *filename) {

--- a/dory/Hardware_targets/PULP/Common/Utils/mem.h
+++ b/dory/Hardware_targets/PULP/Common/Utils/mem.h
@@ -9,6 +9,10 @@ void *ram_malloc(size_t size);
 void  ram_free(void *ptr, size_t size);
 void  ram_read(void *dest, void *src, size_t size);
 void  ram_write(void *dest, void *src, size_t size);
+void *cl_ram_malloc(size_t size);
+void  cl_ram_free(void *ptr, size_t size);
+void  cl_ram_read(void *dest, void *src, size_t size);
+void  cl_ram_write(void *dest, void *src, size_t size);
 size_t load_file_to_ram(const void *dest, const char *filename);
 
 #endif  // __MEM_H__

--- a/dory/Hardware_targets/PULP/GAP8/Templates/vars.mk_template
+++ b/dory/Hardware_targets/PULP/GAP8/Templates/vars.mk_template
@@ -1,0 +1,1 @@
+../../Common/Templates/vars.mk.t

--- a/dory/Hardware_targets/PULP/GAP8_L2/C_Parser.py
+++ b/dory/Hardware_targets/PULP/GAP8_L2/C_Parser.py
@@ -34,6 +34,7 @@ class C_Parser(C_Parser_PULP):
         print("\nGenerating .h weight files.")
         weights_vectors = []
         weights_dimensions = []
+        prefix = self.HWgraph[0].prefix
         for i, node in enumerate(self.HWgraph):
             constants = [0, 0, 0, 0]
             for name in node.constant_names:
@@ -59,20 +60,22 @@ class C_Parser(C_Parser_PULP):
         tk['weights_dimensions'] = weights_dimensions
         tk['DORY_HW_graph'] = self.HWgraph
         tk['sdk'] = node.HW_description["software development kit"]["name"]
+        tk['prefix'] = prefix
         root = os.path.dirname(__file__)
         tmpl = Template(filename=os.path.join(root, "Templates/weights_h_template.h"))
         s = tmpl.render(**tk)
-        save_string = os.path.join(self.inc_dir, 'weights.h')
+        save_string = os.path.join(self.inc_dir, prefix+'weights.h')
         with open(save_string, "w") as f:
             f.write(s)
         tmpl = Template(filename=os.path.join(root, "Templates/weights_definition_h_template.h"))
         s = tmpl.render(**tk)
-        save_string = os.path.join(self.inc_dir, 'weights_definition.h') 
+        save_string = os.path.join(self.inc_dir, prefix+'weights_definition.h') 
         with open(save_string, "w") as f:
             f.write(s)
 
     def create_hex_input(self):
         print("\nGenerating .h input file.")
+        prefix = self.HWgraph[0].prefix
         x_in_l = []
         for in_idx in range(self.n_inputs):
             infile = 'input.txt' if self.n_inputs == 1 else f'input_{in_idx}.txt'
@@ -98,9 +101,10 @@ class C_Parser(C_Parser_PULP):
         tk['input_values'] = input_values
         tk['dimension'] = len(x_in)
         tk['sdk'] = self.HW_description["software development kit"]["name"]
+        tk['prefix'] = prefix
         root = os.path.dirname(__file__)
         tmpl = Template(filename=os.path.join(root, "Templates/input_h_template.h"))
         s = tmpl.render(**tk)
-        save_string = os.path.join(self.inc_dir, 'input.h') 
+        save_string = os.path.join(self.inc_dir, prefix+'input.h') 
         with open(save_string, "w") as f:
             f.write(s)

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/input_h_template.h
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/input_h_template.h
@@ -20,9 +20,9 @@
 #define __INPUT_H__
 #include "pmsis.h"
 % if sdk == 'gap_sdk':
-L2_DATA uint8_t L2_input_h[${dimension}] = {
+L2_DATA uint8_t ${prefix}L2_input_h[${dimension}] = {
 % elif sdk == 'pulp-sdk':
-PI_L2 uint8_t L2_input_h[${dimension}] = {
+PI_L2 uint8_t ${prefix}L2_input_h[${dimension}] = {
 % endif
 ${input_values}};
 #endif

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/input_h_template.h
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/input_h_template.h
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License. 
  */
-#ifndef __INPUT_H__
-#define __INPUT_H__
+#ifndef __${prefix.upper()}INPUT_H__
+#define __${prefix.upper()}INPUT_H__
 #include "pmsis.h"
 % if sdk == 'gap_sdk':
 L2_DATA uint8_t ${prefix}L2_input_h[${dimension}] = {

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_addition_template.c
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_addition_template.c
@@ -32,7 +32,13 @@ ${verbose_log}
 #define VERBOSE_PRINT(...) printf(__VA_ARGS__)
 % endif
 
-
+#ifdef SINGLE_CORE_DMA
+%if sdk == "gap_sdk":
+L1_DATA static uint32_t dory_dma_channel = 0;
+%else:
+PI_L1 static uint32_t dory_dma_channel = 0;
+%endif
+#endif
 
 
 void ${func_name}(
@@ -69,9 +75,14 @@ void ${func_name}(
   int y_length_nof_byte;
   // copy first tiles
   //l2_x has input activations
+#ifndef SINGLE_CORE_DMA
   uint32_t dory_dma_channel = dory_dma_allocate();
+#else
+  if (pi_core_id() == 0)
+    dory_dma_channel = dory_dma_allocate();
+#endif
   volatile DMA_copy DMA_copy_x, DMA_copy_x2, DMA_copy_y;
-  
+
   DMA_copy_x.hwc_to_chw = 0;
   DMA_copy_x.stride_2d = ${x_stride_w_byte};
   DMA_copy_x.stride_1d = ${x_stride_c_byte};

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -32,6 +32,14 @@
 #define VERBOSE_PRINT(...) printf(__VA_ARGS__)
 % endif
 
+#ifdef SINGLE_CORE_DMA
+%if sdk == "gap_sdk":
+L1_DATA static uint32_t dory_dma_channel = 0;
+%else:
+PI_L1 static uint32_t dory_dma_channel = 0;
+%endif
+#endif
+
 void ${func_name}(
   void *args
 ) {
@@ -54,7 +62,12 @@ void ${func_name}(
   /////////////////////
   // DMA declaration //
   /////////////////////
+#ifndef SINGLE_CORE_DMA
   uint32_t dory_dma_channel = dory_dma_allocate();
+#else
+  if (pi_core_id() == 0)
+    dory_dma_channel = dory_dma_allocate();
+#endif
   volatile DMA_copy DMA_copy_k, DMA_copy_lambda;
   volatile DMA_copy DMA_copy_W, DMA_copy_x, DMA_copy_y;
 % if has_bias == 1:

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -297,7 +297,7 @@ void ${func_name}(
   % elif flag_DW == 0 and 'mixed' in optional_type  and ('Gemm' in func_name or 'MatMul' in func_name or 'FullyConnected' in func_name) and y_data_size_byte == 32:
     ${"x" if 'hw' in optional_type else ""}pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
   % elif flag_DW == 0 and 'mixed' in optional_type  and ('Gemm' in func_name or 'MatMul' in func_name or 'FullyConnected' in func_name):
-    pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
+  ${"x" if 'hw' in optional_type else ""}pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
   % elif flag_DW == 1 and optional_type == '8bit' and fs1 == 3 and fs2 == 3 and stride==1:
     pulp_nn_depthwise_generic(
   % elif flag_DW == 1 and optional_type == '8bit' and fs1*fs2 < 4:

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_pooling_template.c
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/layer_templates/layer_L2_c_pooling_template.c
@@ -30,6 +30,16 @@ ${verbose_log}
 % if ULTRA_VERBOSE:
 #define VERBOSE_PRINT(...) printf(__VA_ARGS__)
 % endif
+
+
+#ifdef SINGLE_CORE_DMA
+%if sdk == "gap_sdk":
+L1_DATA static uint32_t dory_dma_channel = 0;
+%else:
+PI_L1 static uint32_t dory_dma_channel = 0;
+%endif
+#endif
+
 void ${func_name}(
   void *args
 ) {
@@ -62,7 +72,13 @@ void ${func_name}(
   int y_length_nof_byte;
  ${type} *im2col;
   im2col = l1_buffer + ${buffer_l1_all};
+
+#ifndef SINGLE_CORE_DMA
   uint32_t dory_dma_channel = dory_dma_allocate();
+#else
+  if (pi_core_id() == 0)
+    dory_dma_channel = dory_dma_allocate();
+#endif
   volatile DMA_copy DMA_copy_x, DMA_copy_y;
   // copy first tiles
   //l2_x has input activations

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/vars.mk_template
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/vars.mk_template
@@ -1,0 +1,1 @@
+../../Common/Templates/vars.mk.t

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/weights_definition_h_template.h
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/weights_definition_h_template.h
@@ -17,11 +17,11 @@
  * limitations under the License. 
  */
 
-#ifndef __WEIGHTS_DEFINITION_H__
-#define __WEIGHTS_DEFINITION_H__
+#ifndef __${prefix.upper()}WEIGHTS_DEFINITION_H__
+#define __${prefix.upper()}WEIGHTS_DEFINITION_H__
 % for i in range(len(weights_vectors)):
 % if weights_dimensions[i] > 0:
-extern uint8_t Weights_${DORY_HW_graph[i].name}[${weights_dimensions[i]}];
+extern uint8_t Weights_${DORY_HW_graph[i].prefixed_name}[${weights_dimensions[i]}];
 % endif
 % endfor
 #endif

--- a/dory/Hardware_targets/PULP/GAP8_L2/Templates/weights_h_template.h
+++ b/dory/Hardware_targets/PULP/GAP8_L2/Templates/weights_h_template.h
@@ -17,8 +17,8 @@
  * limitations under the License. 
  */
 
-#ifndef __WEIGHTS_H__
-#define __WEIGHTS_H__
+#ifndef __${prefix.upper()}WEIGHTS_H__
+#define __${prefix.upper()}WEIGHTS_H__
 % if sdk == 'gap_sdk':
 #include "pulp.h"
 % endif
@@ -27,9 +27,9 @@
 % for i in range(len(weights_vectors)):
 % if weights_dimensions[i] > 0:
 % if sdk == 'gap_sdk':
-L2_DATA uint8_t Weights_${DORY_HW_graph[i].name}[${weights_dimensions[i]}] = {
+L2_DATA uint8_t Weights_${DORY_HW_graph[i].prefixed_name}[${weights_dimensions[i]}] = {
 % elif sdk == 'pulp-sdk':
-PI_L2 uint8_t Weights_${DORY_HW_graph[i].name}[${weights_dimensions[i]}] = {
+PI_L2 uint8_t Weights_${DORY_HW_graph[i].prefixed_name}[${weights_dimensions[i]}] = {
 % endif
 ${weights_vectors[i]}};
 % endif

--- a/dory/Hardware_targets/PULP/PULP_gvsoc/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/PULP/PULP_gvsoc/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -404,7 +404,7 @@ void ${func_name}(
   % elif flag_DW == 0 and 'mixed' in optional_type  and ('Gemm' in func_name or 'MatMul' in func_name or 'FullyConnected' in func_name) and y_data_size_byte == 32:
     ${"x" if 'hw' in optional_type else ""}pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
   % elif flag_DW == 0 and 'mixed' in optional_type  and ('Gemm' in func_name or 'MatMul' in func_name or 'FullyConnected' in func_name):
-    pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
+  ${"x" if 'hw' in optional_type else ""}pulp_nn_linear_${data_type_x[0]}${x_data_size_byte}_${data_type_y[0]}${y_data_size_byte}_${data_type_weights[0]}${W_data_size_byte}(
   % elif flag_DW == 1 and optional_type == '8bit' and fs1 == 3 and fs2 == 3 and stride==1:
     pulp_nn_depthwise_generic(
   % elif flag_DW == 1 and optional_type == '8bit' and fs1*fs2 < 4:

--- a/dory/Hardware_targets/PULP/PULP_gvsoc/Templates/vars.mk_template
+++ b/dory/Hardware_targets/PULP/PULP_gvsoc/Templates/vars.mk_template
@@ -1,0 +1,1 @@
+../../Common/Templates/vars.mk.t

--- a/dory/Parsers/DORY_node.py
+++ b/dory/Parsers/DORY_node.py
@@ -56,6 +56,14 @@ class DORY_node:
         self.conv1d = None
         self.min = None
         self.max = None
+        self.prefix = None
+
+    @property
+    def prefixed_name(self):
+        if self.name and self.prefix:
+            return self.prefix + self.name
+
+        return self.name
 
     def print_parameters(self):
         for parameter in self.__dict__:
@@ -82,7 +90,7 @@ class DORY_node:
             if isinstance(value, type(None)) or (isinstance(value, list) and len(value) == 0):
                 sys.exit("DORY FRONTEND error. Missing some Node initialization. Stopping at argument {}".format(key))
 
-    def populate_DORY_node(self, node_iterating, graph):
+    def populate_DORY_node(self, node_iterating, graph, prefix=""):
         DORY_parameters = {}
         #### Names: Convolution, Addition, FullyConnected, Pooling
         mapping_names = {'AveragePool': 'Pooling', 
@@ -108,6 +116,7 @@ class DORY_node:
         DORY_parameters['output_index'] = node_iterating.output[0]
         DORY_parameters['number_of_input_nodes'] = len(DORY_parameters['input_indexes'])
         DORY_parameters['number_of_input_constants'] = len(DORY_parameters['constant_names'])
+        DORY_parameters['prefix'] = prefix
         self.add_existing_dict_parameter(DORY_parameters)
 
         self.add_constants(node_iterating, graph)

--- a/dory/Parsers/HW_node.py
+++ b/dory/Parsers/HW_node.py
@@ -76,7 +76,12 @@ class HW_node(DORY_node):
             self.tiling_dimensions["L{}".format(level-1)]["output_dimensions"] = output_dims
             if "Convolution" in self.name or "FullyConnected" in self.name:
                 self.tiling_dimensions["L{}".format(level-1)]["weights_dimensions"] = weights_dim
-                groups = self.group if self.group < weights_dim[0] else weights_dim[0]
+                #groups = self.group if self.group < weights_dim[0] else
+                #weights_dim[0] # not really correct: If we tile a grouped
+                #conv, the effective number of groups is the higher of the two
+                #channel numbers
+                groups = self.group if all(self.group < d for d in weights_dim) else max(weights_dim)
+
                 self.tiling_dimensions["L{}".format(level-1)]["weight_memory"] = np.prod(weights_dim)/groups*np.prod(self.kernel_shape)*self.weight_bits/8
             else:
                 self.tiling_dimensions["L{}".format(level-1)]["weight_memory"] = 0

--- a/dory/Parsers/HW_node.py
+++ b/dory/Parsers/HW_node.py
@@ -80,7 +80,7 @@ class HW_node(DORY_node):
                 #weights_dim[0] # not really correct: If we tile a grouped
                 #conv, the effective number of groups is the higher of the two
                 #channel numbers
-                groups = self.group if all(self.group < d for d in weights_dim) else max(weights_dim)
+                groups = self.group if all(self.group <= d for d in weights_dim) else max(weights_dim)
 
                 self.tiling_dimensions["L{}".format(level-1)]["weight_memory"] = np.prod(weights_dim)/groups*np.prod(self.kernel_shape)*self.weight_bits/8
             else:
@@ -163,7 +163,6 @@ class HW_node(DORY_node):
             #### TO CHECK ORDER OF BIASES
             return [np.uint8((el >> shift) & 255) for el in x for shift in range(0, bits, 8)]
 
-        #import ipdb; ipdb.set_trace()
         if bias_name in self.__dict__:
             self.__dict__[bias_name]["value"] = self._to_uint8(self.__dict__[bias_name]['value'].astype(np.int64).ravel(), self.bias_bits)
             self.check_sum_w += sum(self.__dict__[bias_name]["value"])

--- a/dory/Parsers/Layer_node.py
+++ b/dory/Parsers/Layer_node.py
@@ -109,7 +109,7 @@ class Layer_node(DORY_node):
             Layer_parameters = self.update_output_dimensions(activation_tensor, Layer_parameters)
         for activation_tensor in graph.graph.output:
             Layer_parameters = self.update_output_dimensions(activation_tensor, Layer_parameters)
-        if 'Global' in node_iterating.name:
+        if 'Global' in node_iterating.op_type:
             Layer_parameters['kernel_shape'] = Layer_parameters['input_dimensions']
             Layer_parameters['strides'] = [1, 1]
         #### Adding control for layers with g > 1. Only DW (groups = input channels = output channels) and g=1 supported.

--- a/dory/Parsers/Layer_node.py
+++ b/dory/Parsers/Layer_node.py
@@ -42,6 +42,7 @@ class Layer_node(DORY_node):
         self.input_activation_memory = None
         self.output_activation_memory = None
         self.layout = None
+        self.prefix = ""
 
     def update_input_dimensions(self, activation_tensor, Layer_parameters):
         if activation_tensor.name in self.input_indexes:
@@ -78,9 +79,10 @@ class Layer_node(DORY_node):
                 Layer_parameters["output_dimensions"] =  [1, 1]
         return Layer_parameters
 
-    def populate_Layer_node(self, node_iterating, graph):
+    def populate_Layer_node(self, node_iterating, graph, prefix=""):
         self.populate_DORY_node(node_iterating,graph)
         Layer_parameters = {}
+        Layer_parameters['prefix'] = prefix
         ## kernel_shape, dilations, group, strides, pads DEFAULTS
         if self.name in ['FullyConnected', 'Addition']:
             Layer_parameters['kernel_shape'] = [1, 1]

--- a/dory/Parsers/Parser_HW_to_C.py
+++ b/dory/Parsers/Parser_HW_to_C.py
@@ -105,12 +105,13 @@ class Parser_HW_to_C:
             while len(weights) % 4 != 0:
                 weights = np.concatenate((weights, np.asarray([0])))
             if weights.shape[0] != 0:
-                string_layer = node.name + "_weights.hex"
+                string_layer = node.prefixed_name + "_weights.hex"
                 save_s = os.path.join(self.hex_dir, string_layer)
                 weights.astype('uint8').tofile(save_s)
 
     def create_hex_input(self):
         print("\nGenerating .hex input file.")
+        prefix = self.HWgraph[0].prefix
         for in_idx in range(self.n_inputs):
             infile = 'input.txt' if self.n_inputs == 1 else f'input_{in_idx}.txt'
             try:
@@ -128,7 +129,7 @@ class Parser_HW_to_C:
             if in_bits != 8:
                 x_in = HW_node._compress(x_in, in_bits)
 
-            string_layer = "inputs.hex" if self.n_inputs == 1 else f"inputs_{in_idx}.hex"
+            string_layer = prefix+"inputs.hex" if self.n_inputs == 1 else f"{prefix}inputs_{in_idx}.hex"
             save_s = os.path.join(self.hex_dir, string_layer)
             x_in.astype('uint8').tofile(save_s)
 

--- a/dory/Parsers/Parser_ONNX_to_DORY.py
+++ b/dory/Parsers/Parser_ONNX_to_DORY.py
@@ -32,7 +32,7 @@ from dory.Utils.DORY_utils import Printer
 
 class Parser_ONNX_to_DORY:
     # Used to manage the ONNX files. By now, supported Convolutions (PW and DW), Pooling, Fully Connected and Relu.
-    def __init__(self, network, rules, layers_accepted, layers_neglected, layers_to_node):
+    def __init__(self, network, rules, layers_accepted, layers_neglected, layers_to_node, net_prefix=""):
         self.graph = onnx.load(network)
         self.Printer_Frontend = Printer("logs/Frontend")
         self.Printer_Frontend.print_onnx("Original_graph", self.graph)
@@ -43,6 +43,8 @@ class Parser_ONNX_to_DORY:
         self.layers_to_node = layers_to_node
         self.layers_supported_by_DORY_Frontend_IR = ["Convolution", "Pooling", "FullyConnected", "Addition", "QAddition", "Relu", "BNRelu", "Requant"]
         self.rules = rules
+        self.net_prefix = net_prefix
+        print(f"onnx_to_dory net prefix: {net_prefix}")
         self.DORY_Graph = []
 
     def create_node(self, node_iterating, graph):
@@ -51,10 +53,10 @@ class Parser_ONNX_to_DORY:
         As an alternative, create a DORY node (Mul, Shift, Div, Clip, etc...).
         '''
         new_node = DORY_node.DORY_node()
-        new_node.populate_DORY_node(node_iterating,graph)
+        new_node.populate_DORY_node(node_iterating,graph, self.net_prefix)
         if new_node.name in ['FullyConnected', 'Addition', 'Convolution', 'Pooling']:
             new_node = Layer_node.Layer_node()
-            new_node.populate_Layer_node(node_iterating,graph)
+            new_node.populate_Layer_node(node_iterating,graph, self.net_prefix)
         return new_node
 
     def ONNXtoDORY(self):
@@ -73,7 +75,7 @@ class Parser_ONNX_to_DORY:
             elif node_iterating.op_type in self.layers_accepted:
                 new_node = self.create_node(node_iterating, self.graph)
                 self.DORY_Graph.append(new_node)
-            else: 
+            else:
                 sys.exit("DORY Frontend. Node not parsed.")
 
     def remove_Constants(self):

--- a/dory/Utils/Templates_writer/Layer2D_template_writer.py
+++ b/dory/Utils/Templates_writer/Layer2D_template_writer.py
@@ -231,8 +231,8 @@ def print_template_layer(node, layer_type, tmpl_dir, out_dir, double_buffering =
     dt_W       = node.weight_type
 
     if "Addition" in node.name:
-        ds_x2  = node.input_activation_bits
-        dt_x2  = node.input_activation_type
+        ds_x2  = node.second_input_activation_bits
+        dt_x2  = node.second_input_activation_type
         tk["data_type_x2"] = dt_x2
         tk['x_data_size_byte2'] = ds_x2
         tk["inmul1"] = node.inmul1["value"]
@@ -397,7 +397,6 @@ def print_template_layer(node, layer_type, tmpl_dir, out_dir, double_buffering =
         tk['W_tile_size_nof_last'] = n_out % tile_n_out if (n_out % tile_n_out) > 0 else tile_n_out
         tk['W_tile_size_nif_last'] = tk['W_tile_size_nif']
         tk['W_tile_size_nif_byte_last'] = int(math.ceil(tk['W_tile_size_nif_last'] * ds_W / 8.0))
-    
     # y last
     tk['y_tile_size_nof_last'] = n_out % tile_n_out if (n_out % tile_n_out) > 0 else tile_n_out
     tk['y_tile_size_h_last'] = h_out % tile_h_out if (h_out % tile_h_out) > 0 else tile_h_out

--- a/dory/Utils/Templates_writer/Layer2D_template_writer.py
+++ b/dory/Utils/Templates_writer/Layer2D_template_writer.py
@@ -92,10 +92,10 @@ def print_template_layer_L3(node, tmpl_dir, out_dir):
     tk['n_tile_y'] = factor_h_out
     tk['verbose'] = False
     if tk['padding'] > 0:
-        tk['func_name'] = [node.name + "_L2", node.name + "_L2_p_t", node.name + "_L2_p_b"]
+        tk['func_name'] = [node.prefixed_name + "_L2", node.prefixed_name + "_L2_p_t", node.prefixed_name + "_L2_p_b"]
     else:
-        tk['func_name'] = [node.name + "_L2"]
-    tk['func_name_L3'] = node.name
+        tk['func_name'] = [node.prefixed_name + "_L2"]
+    tk['func_name_L3'] = node.prefixed_name
     tk['BitIn'] = ds_x
     tk['y_data_size_byte'] = ds_y
     tk['x_data_size_byte'] = ds_x
@@ -140,13 +140,13 @@ def print_template_layer_L3(node, tmpl_dir, out_dir):
     tmpl = Template(filename=os.path.join(tmpl_dir, "layer_L3_c_template.c"))
     l = ""
     s = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(out_dir, 'src', node.name + '.c')
+    save_string = os.path.join(out_dir, 'src', node.prefixed_name + '.c')
     with open(save_string, "w") as f:
         f.write(s)
     tmpl = Template(filename=os.path.join(tmpl_dir, "layer_L3_h_template.h"))
     l = ""
     s = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(out_dir, 'inc', node.name + '.h')
+    save_string = os.path.join(out_dir, 'inc', node.prefixed_name + '.h')
     with open(save_string, "w") as f:
         f.write(s)
 
@@ -160,7 +160,7 @@ def print_template_layer(node, layer_type, tmpl_dir, out_dir, double_buffering =
     p =       node.pads
     conv_overlap_h = 2 * (ks[0] // 2) + ks[0] % 2 - 1 - (s[0] - 1)
     padding_top = p[0]; padding_left = p[1]; padding_bottom = p[2]; padding_right = p[3];
-    name_layer = node.name + '.h'
+    name_layer = node.prefixed_name + '.h'
     conv_overlap1 = 2 * (ks[0] // 2) + ks[0] % 2 - 1 - (s[0] - 1)
     conv_overlap2 = 2 * (ks[1] // 2) + ks[1] % 2 - 1 - (s[1] - 1)
     tk = OrderedDict([])
@@ -176,7 +176,7 @@ def print_template_layer(node, layer_type, tmpl_dir, out_dir, double_buffering =
     tk['sdk'] = node.HW_description["software development kit"]["name"]
     tk['number_of_clusters'] = node.HW_description["HW specific parameters"]["clusters"] if "clusters" in node.HW_description["HW specific parameters"].keys() else 1
     tk['optional_type'] = layer_type
-    tk['func_name'] = node.name
+    tk['func_name'] = node.prefixed_name
     tk['flag_DW'] = 1 if node.group > 1 else 0
     tk['optional'] = node.op_type
     tk['FLAG_BATCHNORM'] = 1 if 'k' in node.constant_names else 0
@@ -454,7 +454,7 @@ def print_template_layer(node, layer_type, tmpl_dir, out_dir, double_buffering =
             tmpl = Template(filename=os.path.join(tmpl_dir, "layer_L2_c_addition_template.c"))
 
     s_c = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(out_dir, 'src', name_layer.replace("h", "c"))
+    save_string = os.path.join(out_dir, 'src', name_layer.replace(".h", ".c"))
     with open(save_string, "w") as f:
         f.write(s_c)
     tmpl = Template(filename=os.path.join(tmpl_dir, "layer_L2_h_template.h"))

--- a/dory/Utils/Templates_writer/Makefile_template_writer.py
+++ b/dory/Utils/Templates_writer/Makefile_template_writer.py
@@ -32,9 +32,10 @@ def print_template_Makefile(
     file_list_w = []
     for i, node in enumerate(graph):
         if "Conv" in node.name or "FullyConnected" in node.name:
-            file_list_w.append(node.name+"_weights.hex")
+            file_list_w.append(node.prefixed_name+"_weights.hex")
 
     tk['n_inputs'] = graph[0].n_test_inputs
+    tk['prefix'] = graph[0].prefix
     tk['layers_w'] = file_list_w
     tk['sdk'] = HW_description["software development kit"]["name"]
     tk['do_flash'] = HW_description["memory"]["levels"] > 2

--- a/dory/Utils/Templates_writer/Makefile_template_writer.py
+++ b/dory/Utils/Templates_writer/Makefile_template_writer.py
@@ -46,6 +46,12 @@ def print_template_Makefile(
         print("Makefile template writer: key 'always_blocking_dma_transfers' not found in HW description, using non-blocking transfers!")
         blocking_dma_transfers = False
     tk['blocking_dma'] = blocking_dma_transfers
+    try:
+        single_core_dma = HW_description['single_core_dma']
+    except KeyError:
+        print("Makefile template writer: key 'single_core_dma' not found in HW description, using multi-core transfers!")
+        single_core_dma = False
+    tk['single_core_dma'] = single_core_dma
     root = os.path.realpath(os.path.dirname(__file__))
     tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], template_location_rel))
     s = tmpl.render(**tk)

--- a/dory/Utils/Templates_writer/Makefile_template_writer.py
+++ b/dory/Utils/Templates_writer/Makefile_template_writer.py
@@ -26,7 +26,8 @@ def print_template_Makefile(
     graph,
     HW_description,
     save_string,
-    app_directory):
+        app_directory,
+        template_location_rel="Templates/Makefile_template"):
     # Generate the Makefile, including all files to upload on the hyperflash
     tk = OrderedDict([])
     file_list_w = []
@@ -46,7 +47,7 @@ def print_template_Makefile(
         blocking_dma_transfers = False
     tk['blocking_dma'] = blocking_dma_transfers
     root = os.path.realpath(os.path.dirname(__file__))
-    tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], "Templates/Makefile_template"))
+    tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], template_location_rel))
     s = tmpl.render(**tk)
     save_string = os.path.join(app_directory, save_string)
     with open(save_string, "w") as f:

--- a/dory/Utils/Templates_writer/Network_template_writer.py
+++ b/dory/Utils/Templates_writer/Network_template_writer.py
@@ -35,6 +35,8 @@ def print_template_network(
 ):
     # Generate the Network management c file.
     tk = OrderedDict([])
+    prefix = graph[0].prefix
+    tk['prefix'] = prefix
     if 'Check' in verbose_level:
         tk['verbose'] = True
     else:
@@ -57,9 +59,9 @@ def print_template_network(
     for i, node in enumerate(graph):
         MACs += node.MACs
         if "Conv" in node.name or "FullyConnected" in node.name:
-            file_list_w.append(node.name+"_weights.hex")
-        list_h.append(node.name+".h")
-        list_name.append(node.name)
+            file_list_w.append(node.prefixed_name+"_weights.hex")
+        list_h.append(node.prefixed_name+".h")
+        list_name.append(node.prefixed_name)
     tk['MACs'] = MACs
     tk['files_list'] = utils.print_file_list(file_list_w)
     tk['fc_frequency'] = HW_description["core frequency"]
@@ -76,24 +78,24 @@ def print_template_network(
         except TypeError:
             try:
                 l += "// %s %d\n" % (k.ljust(30), v[0])
-            except TypeError:
+            except (TypeError, IndexError):
                 l += "// %s %s\n" % (k.ljust(30), v)
     tk['DORY_HW_graph'] = graph
     root = os.path.realpath(os.path.dirname(__file__))
     tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], "Templates/network_c_template.c"))
     s = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(app_directory, src_dir_rel, 'network.c') 
+    save_string = os.path.join(app_directory, src_dir_rel, prefix + 'network.c')
     with open(save_string, "w") as f:
         f.write(s)
 
     tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], "Templates/network_h_template.h"))
     s = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(app_directory, inc_dir_rel, 'network.h') 
+    save_string = os.path.join(app_directory, inc_dir_rel, prefix + 'network.h')
     with open(save_string, "w") as f:
         f.write(s)
 
     tmpl = Template(filename=os.path.join(root, "../../Hardware_targets", HW_description["name"], "Templates/main_template.c"))
     s = tmpl.render(verbose_log=l, **tk)
-    save_string = os.path.join(app_directory, src_dir_rel, 'main.c')
+    save_string = os.path.join(app_directory, src_dir_rel, prefix + 'main.c')
     with open(save_string, "w") as f:
         f.write(s)

--- a/network_generate.py
+++ b/network_generate.py
@@ -41,9 +41,11 @@ def dory_to_c(graph, target, conf, confdir, verbose_level, perf_layer, optional,
 
 
 def network_generate(frontend, target, conf_file, verbose_level='Check_all+Perf_final', perf_layer='No', optional='auto',
-                     appdir='./application'):
+                     appdir='./application', prefix=""):
     print(f"Using {frontend} as frontend. Targeting {target} platform. ")
 
+    if len(prefix) > 0 and prefix[-1] != "_":
+        prefix += "_"
     # Reading the json configuration file
     with open(conf_file) as f:
         conf = json.load(f)
@@ -63,7 +65,7 @@ def network_generate(frontend, target, conf_file, verbose_level='Check_all+Perf_
     # Including and running the transformation from Onnx to a DORY compatible graph
     onnx_manager = import_module(f'dory.Frontend_frameworks.{frontend}.Parser')
     onnx_to_dory = onnx_manager.onnx_manager
-    graph = onnx_to_dory(onnx_file, conf).full_graph_parsing()
+    graph = onnx_to_dory(onnx_file, conf, prefix).full_graph_parsing()
 
     dory_to_c(graph, target, conf, confdir, verbose_level, perf_layer, optional, appdir, n_inputs)
 
@@ -86,8 +88,9 @@ if __name__ == '__main__':
     parser.add_argument('--optional', default='auto',
                         help='auto (based on layer precision, 8bits or mixed-sw), 8bit, mixed-hw, mixed-sw')
     parser.add_argument('--app_dir', default='./application', help='Path to the generated application. Default: ./application')
+    parser.add_argument('--prefix', default="", help='Prefix to prepend to network-specific generated functions', type=str)
 
     args = parser.parse_args()
 
     network_generate(args.frontend, args.hardware_target, args.config_file, args.verbose_level, args.perf_layer,
-                     args.optional, args.app_dir)
+                     args.optional, args.app_dir, args.prefix)


### PR DESCRIPTION
Added features & bugfixes:
- tiler bugs fixed
- many other bugs fixed (too many to list)
- change PULP network template to run all code in a single cluster call
- add option to prefix a network's generated code with the `--prefix` option. This allows easy assembly of multi-net applications by giving each generated net application a different prefix.
- Added support for `single_core_dma` option to PULP `HW_description.json`s - this will execute all DMA calls on a single DMA