### PR TITLE
Fix HW_Parser pointing to GAP8

### DIFF
--- a/dory/Hardware_targets/PULP/GAP9/C_Parser.py
+++ b/dory/Hardware_targets/PULP/GAP9/C_Parser.py
@@ -15,14 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dory.Hardware_targets.PULP.Common import C_Parser_PULP
+from dory.Hardware_targets.PULP.Common import C_Parser_PULP
 import os
 
-class C_Parser(C_Parser_PULP):
+
+class C_Parser(C_Parser_PULP):
+
     def __init__(self, *args, **kwargs):
         super(C_Parser, self).__init__(*args, **kwargs)
         if self.precision_library == "mixed-hw":
-            assert False, "optional='mixed-hw' not compatible with GAP8!"
+            assert False, "optional='mixed-hw' not compatible with GAP9!"
 
     def get_file_path(self):
         return "/".join(os.path.realpath(__file__).split("/")[:-1])

--- a/dory/Hardware_targets/PULP/GAP9/HW_Parser.py
+++ b/dory/Hardware_targets/PULP/GAP9/HW_Parser.py
@@ -15,12 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dory.Hardware_targets.PULP.Common import onnx_manager_PULP
-from dory.Hardware_targets.PULP.GAP8.HW_Pattern_rewriter import Pattern_rewriter
-from dory.Hardware_targets.PULP.GAP8.Tiler import Tiler
+from dory.Hardware_targets.PULP.Common import onnx_manager_PULP
+from dory.Hardware_targets.PULP.GAP9.HW_Pattern_rewriter import Pattern_rewriter
+from dory.Hardware_targets.PULP.GAP9.Tiler import Tiler
 import os
 
-class onnx_manager(onnx_manager_PULP):
+
+class onnx_manager(onnx_manager_PULP):
+
     def get_file_path(self):
         return "/".join(os.path.realpath(__file__).split("/")[:-1])
 


### PR DESCRIPTION
Functionally it is still the same because GAP8's
classes used then the common PULP ones. This is
to prevent future mistakes.