### PR TITLE
Add BackendKernelAdapter

### DIFF
--- a/dory/Hardware_targets/PULP/Backend_Kernels/BackendKernelsAdapter.py
+++ b/dory/Hardware_targets/PULP/Backend_Kernels/BackendKernelsAdapter.py
@@ -1,0 +1,168 @@
+from typing import Literal, List, Union
+import os
+
+from dory.Parsers.HW_node import HW_node
+
+
+class BackendKernelsAdapter:
+    def __init__(self, dirname: str, node: HW_node):
+        self.dirname = dirname
+        self._check_valid_node(node)
+        self.node = node
+
+    def _check_valid_node(self, node: HW_node) -> None:
+        _ = node
+        raise NotImplementedError()
+
+    def _root_dir(self) -> Union[os.PathLike, str]:
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)), self.dirname)
+
+    def _get_src_files(self) -> List[str]:
+        raise NotImplementedError()
+
+    def _get_inc_files(self) -> List[str]:
+        raise NotImplementedError()
+
+    @staticmethod
+    def _filter(files: List[str], extension: str):
+        return [file for file in files if file.endswith(extension)]
+
+    def get_src_files(self) -> List[str]:
+        return BackendKernelsAdapter._filter(self._get_src_files(), ".c")
+
+    def get_inc_files(self) -> List[str]:
+        return BackendKernelsAdapter._filter(self._get_inc_files(), ".h")
+
+
+class PulpNNAdapter(BackendKernelsAdapter):
+    def __init__(self, dirname: str, node: HW_node, constant_bits: int):
+        super().__init__(dirname, node)
+        self.constant_bits = constant_bits
+
+    def _check_valid_node(self, node: HW_node) -> None:
+        _ = node
+        assert True
+
+    def _src_dir(self) -> Union[os.PathLike, str]:
+        return os.path.join(self._root_dir(), "{}bit/src".format(self.constant_bits))
+
+    def _inc_dir(self) -> Union[os.PathLike, str]:
+        return os.path.join(
+            self._root_dir(), "{}bit/include".format(self.constant_bits)
+        )
+
+    def _get_src_files(self) -> List[str]:
+        path, _, src_files = next(os.walk(self._src_dir()))
+        return [os.path.join(path, file) for file in src_files]
+
+    def _get_inc_files(self) -> List[str]:
+        path, _, inc_files = next(os.walk(self._inc_dir()))
+        return [os.path.join(path, file) for file in inc_files]
+
+
+class PulpMixedAdapter(PulpNNAdapter):
+    def __init__(
+        self,
+        dirname: str,
+        node: HW_node,
+        constant_bits: int,
+        _type: Literal["hw", "sw"],
+    ):
+        self._type = _type
+        if _type == "hw":
+            dirname = os.path.join(dirname, "XpulpNN")
+        elif _type == "sw":
+            dirname = os.path.join(dirname, "XpulpV2")
+        else:
+            assert (
+                False
+            ), "ERROR: Unrecognised PulpMixed kernel library type: {}".format(_type)
+        super().__init__(dirname, node, constant_bits)
+
+    def _check_valid_node(self, node: HW_node) -> None:
+        _ = node
+        assert True
+
+    def _get_src_files(self) -> List[str]:
+        in_bits = str(self.node.get_parameter("input_activation_bits"))
+        out_bits = str(self.node.get_parameter("output_activation_bits"))
+        in_type = self.node.get_parameter("input_activation_type")[0]
+        out_type = self.node.get_parameter("output_activation_type")[0]
+
+        out = "_" + out_type + out_bits
+        in_out = "_" + in_type + in_bits + out
+        maybe_x = "x" if self._type == "hw" else ""
+
+        src_files = []
+
+        assert isinstance(self.node.name, str)
+        assert isinstance(self.node.op_type, str)
+
+        if "Addition" in self.node.name:
+            in1_in2_out = (
+                "_"
+                + in_type
+                + in_bits
+                + "_"
+                + self.node.get_parameter("second_input_activation_type")[0]
+                + str(self.node.get_parameter("second_input_activation_bits"))
+                + "_"
+                + out_type
+                + out_bits
+            )
+            src_files.append(f"Add/{maybe_x}pulp_nn_add{in1_in2_out}.c")
+        elif "Pool" in self.node.name and "Max" in self.node.op_type:
+            src_files.append(f"Pooling/MaxPool/{maybe_x}pulp_nn_maxpool{out}.c")
+        elif "Pool" in self.node.name and (
+            "Avg" in self.node.op_type or "Average" in self.node.op_type
+        ):
+            src_files.append(f"Pooling/AvgPool/{maybe_x}pulp_nn_avgpool{in_out}.c")
+
+        in_out_weights = (
+            "_"
+            + in_type
+            + in_bits
+            + "_"
+            + out_type
+            + out_bits
+            + "_"
+            + self.node.get_parameter("weight_type")[0]
+            + str(self.node.get_parameter("weight_bits"))
+        )
+        if "Conv" in self.node.name and self.node.group > 1:
+            src_files.append(f"Depthwise/{maybe_x}pulp_nn_depthwise{in_out_weights}.c")
+        elif "Conv" in self.node.name and self.node.group == 1:
+            if self.node.conv1d and self._type == "hw":
+                src_files.append(f"Convolution/xpulp_nn_conv1d{in_out_weights}.c")
+            else:
+                src_files.append(f"Convolution/{maybe_x}pulp_nn_conv{in_out_weights}.c")
+        elif (
+            "FullyConnected" in self.node.name
+            and self.node.output_activation_bits == 32
+        ):
+            src_files.append(f"LinearNoQuant/{maybe_x}pulp_nn_linear{in_out_weights}.c")
+        elif "FullyConnected" in self.node.name:
+            src_files.append(f"LinearQuant/{maybe_x}pulp_nn_linear{in_out_weights}.c")
+
+        if (
+            "Conv" in self.node.name or "FullyConnected" in self.node.name
+        ) and self.node.get_parameter("output_activation_bits") != 32:
+            in_bits_matmul = "8" if self._type == "sw" else str(in_bits)
+            in_out_weights = (
+                "_"
+                + in_type
+                + in_bits_matmul
+                + "_"
+                + out_type
+                + out_bits
+                + "_"
+                + self.node.get_parameter("weight_type")[0]
+                + str(self.node.get_parameter("weight_bits"))
+            )
+            src_files.append(
+                f"MatrixMultiplication/{maybe_x}pulp_nn_matmul{in_out_weights}.c"
+            )
+
+        src_files = [os.path.join(self._src_dir(), file) for file in src_files]
+
+        return src_files

--- a/dory/Hardware_targets/PULP/Common/C_Parser.py
+++ b/dory/Hardware_targets/PULP/Common/C_Parser.py
@@ -35,7 +35,7 @@ class C_Parser_PULP(Parser_HW_to_C):
         file_path = self.get_file_path()
         with open(os.path.join(file_path, "HW_description.json")) as f:
             HW_description = json.load(f)
-        self.precision_library = precision_library
+        self.precision_library = C_Parser_PULP._auto_precision_library(graph) if precision_library == "auto" else precision_library
         self.source_Constant_bits_library = config_file["BNRelu_bits"]
         self.config_file = config_file
         super().__init__(graph, os.path.join(config_file_dir, os.path.dirname(config_file["onnx_file"])), HW_description, verbose_level, perf_layer, "Makefile", app_directory, n_inputs)
@@ -46,27 +46,33 @@ class C_Parser_PULP(Parser_HW_to_C):
             db = 2
         self.double_buffering = db
 
+    @staticmethod
+    def _auto_precision_library(graph):
+        precision_library = "8bit"
+        for node in graph:
+            if "Addition" not in node.name and "Pool" not in node.name:
+                if node.get_parameter('output_activation_bits') < 8 or node.get_parameter('input_activation_bits') < 8 or node.get_parameter('weight_bits') < 8:
+                    precision_library = 'mixed-sw'
+            else:
+                if node.get_parameter('output_activation_bits') < 8 or node.get_parameter('input_activation_bits') < 8:
+                    precision_library = 'mixed-sw'
+        return precision_library
+
     def get_file_path(self):
         raise NotImplementedError("To be implemented by child class!")
 
-    def copy_backend_files(self, node):
-        if self.precision_library == 'auto':
-            self.precision_library = '8bit'
-            if "Addition" not in node.name and "Pool" not in node.name:
-                if node.get_parameter('output_activation_bits') < 8 or node.get_parameter('input_activation_bits') < 8 or node.get_parameter('weight_bits') < 8:
-                    self.precision_library = 'mixed-sw'
-            else:
-                if node.get_parameter('output_activation_bits') < 8 or node.get_parameter('input_activation_bits') < 8:
-                    self.precision_library = 'mixed-sw'
+    def node_backend_library(self, node):
+        return self.precision_library
 
-        if self.precision_library == "8bit":
+    def copy_backend_files(self, node, backend_library):
+        if backend_library == "8bit":
             backendKernelsAdapter = BackendKernelsAdapter.PulpNNAdapter("pulp-nn", node, self.source_Constant_bits_library)
-        elif self.precision_library == "mixed-sw":
+        elif backend_library == "mixed-sw":
             backendKernelsAdapter = BackendKernelsAdapter.PulpMixedAdapter("pulp-nn-mixed", node, self.source_Constant_bits_library, "sw")
-        elif self.precision_library == "mixed-hw":
+        elif backend_library == "mixed-hw":
             backendKernelsAdapter = BackendKernelsAdapter.PulpMixedAdapter("pulp-nn-mixed", node, self.source_Constant_bits_library, "hw")
         else:
-            raise ValueError(f"Unrecognised backend library: {self.precision_library}")
+            raise ValueError(f"Unrecognised backend library: {backend_library}")
 
         src_dir = os.path.join(self.app_directory, self.src_dir_rel)
         for file in backendKernelsAdapter.get_src_files():
@@ -82,7 +88,8 @@ class C_Parser_PULP(Parser_HW_to_C):
         out_dir = self.app_directory
         n_memory_levels = self.HW_description['memory']['levels']
         for i, node in enumerate(self.HWgraph):
-            self.copy_backend_files(node)
+            backend_library = self.node_backend_library(node)
+            self.copy_backend_files(node, backend_library)
 
             if n_memory_levels > 2 and (node.L3_input != 0 or (node.tiling_dimensions["L3"]["output_dimensions"] != node.tiling_dimensions["L2"]["output_dimensions"]) or (node.tiling_dimensions["L3"]["weights_dimensions"] != node.tiling_dimensions["L2"]["weights_dimensions"])):
                 Layer2D_writer.print_template_layer_L3(node, tmpl_dir, out_dir)
@@ -93,12 +100,12 @@ class C_Parser_PULP(Parser_HW_to_C):
                 node.name = node.name + "_L2"
                 padding = node.pads
                 node.pads = [0, padding[1], 0, padding[3]]
-                Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
+                Layer2D_writer.print_template_layer(node, backend_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
                 node.name = node.name[:-3]
                 if padding[0] > 0:
                     node.name = node.name + "_L2_p_t"
                     node.pads = [padding[0], padding[1], 0, padding[3]]
-                    Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
+                    Layer2D_writer.print_template_layer(node, backend_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
                     node.name = node.name[:-1] + "b"
                     node.pads = [0, padding[1], padding[2], padding[3]]
                     node.tiling_dimensions["L2"]["input_dimensions"][1] -= (padding[2] - ((node.tiling_dimensions["L3"]["input_dimensions"][1] + padding[0] + padding[2]) - (node.tiling_dimensions["L3"]["output_dimensions"][1]* node.strides[0] + node.kernel_shape[0] - node.strides[0])))
@@ -106,14 +113,14 @@ class C_Parser_PULP(Parser_HW_to_C):
                         node.tiling_dimensions["L1"]["input_dimensions"][1] = node.tiling_dimensions["L2"]["input_dimensions"][1]
                     if node.tiling_dimensions["L1"]["output_dimensions"][1] > node.tiling_dimensions["L2"]["output_dimensions"][1]:
                         node.tiling_dimensions["L1"]["output_dimensions"][1] = node.tiling_dimensions["L2"]["output_dimensions"][1]
-                    Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
+                    Layer2D_writer.print_template_layer(node, backend_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
                     node.name = node.name[:-7]
             else:
                 if node.tiling_dimensions["L2"]["input_dimensions"][2] == node.tiling_dimensions["L1"]["input_dimensions"][2]:
                     node.tiling_dimensions["L1"]["output_dimensions"][2] = int((node.tiling_dimensions["L1"]["input_dimensions"][2] + (node.pads[1] + node.pads[3]) - node.kernel_shape[1] + node.strides[1]) / node.strides[1])
                 if node.tiling_dimensions["L2"]["input_dimensions"][1] == node.tiling_dimensions["L1"]["input_dimensions"][1]:
                     node.tiling_dimensions["L1"]["output_dimensions"][1] = int((node.tiling_dimensions["L1"]["input_dimensions"][1] + (node.pads[0] + node.pads[2]) - node.kernel_shape[0] + node.strides[0]) / node.strides[0])
-                Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
+                Layer2D_writer.print_template_layer(node, backend_library, tmpl_dir, out_dir, double_buffering=self.double_buffering)
 
     def mapping_makefile(self):
         super(C_Parser_PULP, self).mapping_makefile()


### PR DESCRIPTION
The BackendKerneAdapter class would encapsulate the include/source file finding for each backend library. Preparation for adding the pulp-nnx backend library.

Additionally, changed the decision making for the "auto" precision library to be done during initialization and uniformly for the whole graph, i.e. if the graph needs "mixed-sw" it will use "mixed-sw" for every node, even though it might use somewhere "8bit".