### PR TITLE
Refactor Template writer

### DIFF
--- a/dory/Hardware_targets/Occamy/C_Parser.py
+++ b/dory/Hardware_targets/Occamy/C_Parser.py
@@ -26,6 +26,7 @@ import numpy as np
 # DORY modules
 from dory.Parsers.Parser_HW_to_C import Parser_HW_to_C
 import dory.Utils.Templates_writer.Layer2D_template_writer as Layer2D_writer
+from dory.Utils.Templates_writer.TemplateWriter import TemplateWriter
 
 # Directory
 file_path = "/".join(os.path.realpath(__file__).split("/")[:-1])
@@ -63,6 +64,8 @@ class C_Parser(Parser_HW_to_C):
                 node.tiling_dimensions["L1"]["output_dimensions"][2] = int((node.tiling_dimensions["L1"]["input_dimensions"][2] + (node.pads[1] + node.pads[3]) - node.kernel_shape[1] + node.strides[1]) / node.strides[1])
             if node.tiling_dimensions["L2"]["input_dimensions"][1] == node.tiling_dimensions["L1"]["input_dimensions"][1]:
                 node.tiling_dimensions["L1"]["output_dimensions"][1] = int((node.tiling_dimensions["L1"]["input_dimensions"][1] + (node.pads[0] + node.pads[2]) - node.kernel_shape[0] + node.strides[0]) / node.strides[0])
-            Layer2D_writer.print_template_layer(node, self.precision_library, tmpl_dir, out_dir)
+            tk = Layer2D_writer.print_template_layer(node, self.precision_library)
+            tm = self.l2_template_mapping(node, self.precision_library)
+            TemplateWriter.write(tk, tm)
 
 

--- a/dory/Parsers/Parser_HW_to_C.py
+++ b/dory/Parsers/Parser_HW_to_C.py
@@ -69,6 +69,27 @@ class Parser_HW_to_C:
             self.save_string_for_Makefile,
             self.app_directory)
 
+    def l2_c_template(self, node, backend_library):
+        if "Pool" in node.name:
+            if(backend_library == '1D_Conv'):
+                return "pooling_layer_1D_template.c"
+            else:
+                return "layer_L2_c_pooling_template.c"
+        elif "Addition" in node.name:
+            if(backend_library == '1D_Conv'):
+                return "add_layer_1D_template.c"
+            else:
+                return "layer_L2_c_addition_template.c"
+        else:
+            return "layer_L2_c_conv_template.c"
+
+    def l2_template_mapping(self, node, backend_library):
+        tmpl_c = self.l2_c_template(node, backend_library)
+        return {
+            os.path.join(self.src_dir, node.prefixed_name + ".c"): os.path.join(self.tmpl_dir, tmpl_c),
+            os.path.join(self.inc_dir, node.prefixed_name + ".h"): os.path.join(self.tmpl_dir, "layer_L2_h_template.h"),
+        }
+
     def mapping_layers_to_C_files(self):
         print("\nTo be implemented in the target backend")
 
@@ -144,6 +165,13 @@ class Parser_HW_to_C:
     @property
     def hex_dir(self):
         return os.path.join(self.app_directory, self.hex_dir_rel)
+
+    def get_file_path(self):
+        raise NotImplementedError("To be implemented by child class!")
+
+    @property
+    def tmpl_dir(self):
+        return os.path.realpath(os.path.join(self.get_file_path(), 'Templates/layer_templates'))
 
     def full_graph_parsing(self):
         print("#####################################################")

--- a/dory/Utils/Templates_writer/TemplateWriter.py
+++ b/dory/Utils/Templates_writer/TemplateWriter.py
@@ -1,0 +1,13 @@
+from mako.template import Template
+from typing import Dict, Any
+
+
+class TemplateWriter:
+
+    @staticmethod
+    def write(templateKeywordDict: Dict[str, Any], templateMapping: Dict[str, str]):
+        for dest, template in templateMapping.items():
+            render = Template(filename=template).render(**templateKeywordDict)
+            assert isinstance(render, str)
+            with open(dest, "w") as fp:
+                fp.write(render)

--- a/dory/Utils/Templates_writer/TemplateWriter.py
+++ b/dory/Utils/Templates_writer/TemplateWriter.py
@@ -7,7 +7,12 @@ class TemplateWriter:
     @staticmethod
     def write(templateKeywordDict: Dict[str, Any], templateMapping: Dict[str, str]):
         for dest, template in templateMapping.items():
-            render = Template(filename=template).render(**templateKeywordDict)
+            # Flag strict_undefined enables reporting of names of the undefined variables (very useful)
+            # but expects all the variables to be defined which is not our case. We do some conditional
+            # rendering with flags like has_bias, has_batchnorm, etc. so some variables raise undefined
+            # error even though they wouldn't be used. For now keep strict_undefined as False, until
+            # the keyword generation gets changed to generate all the kewywords.
+            render = Template(filename=template, strict_undefined=False).render(**templateKeywordDict)
             assert isinstance(render, str)
             with open(dest, "w") as fp:
                 fp.write(render)


### PR DESCRIPTION
Extracted the template writing from Layer2D_template_writer so that I can change the template name. For GAP9 w/ NE16 I will have 2 templates, one for convolution on the cluster and the other on the NE16 so this will enable to choose the template.

Furthermore, extracted a few more functions in the HW_Parser so they can be overriden, e.g. l2_template_keywords, l2_template_mapping, l2_c_template.

Additionally, I accidentally found out about the very useful "strict_undefined" flag for Mako templates which unfortunately doesn't work for us because of the way our templates are written at the moment. I left a comment for anyone who stumbles upon it in the future.