### PR TITLE
Partial fix for Diana_TVM when layer dimensions are not a multiple of 16

### DIFF
--- a/dory/Hardware_targets/Diana/Diana_TVM/C_Parser.py
+++ b/dory/Hardware_targets/Diana/Diana_TVM/C_Parser.py
@@ -133,7 +133,7 @@ class C_Parser(Parser_HW_to_C):
                         final_weights = []
                         for ch in range(int((node.output_channels+15)/16)):
                             for byte in range(4):
-                                final_weights.append(new_weights[(node.output_channels*byte + ch*16):(node.output_channels*byte + ch*16 + 16)])
+                                final_weights.append(new_weights[(16*byte + ch*16):(16*byte + ch*16 + 16)])
                     else:
                         new_weights = []
                         for pos in range(4):

--- a/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
+++ b/dory/Hardware_targets/Diana/Diana_TVM/Templates/layer_templates/layer_L2_c_conv_template.c
@@ -104,7 +104,11 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
   // tile loop nest
   for(iter=0; iter < total_tiles; iter++) {
     // check if last in any dimension
+% if "Gemm" in optional:
     x_tile_size_nif = (_i_nif+1   == ${tile_dim_nif}) ? ${(x_tile_size_nif_last + 15) // 16 * 16} : ${(x_tile_size_nif + 15) // 16 * 16};
+% else:
+    x_tile_size_nif = (_i_nif+1 == ${tile_dim_nif}) ? ${x_tile_size_nif_last} : ${x_tile_size_nif};
+% endif
     x_tile_size_h   = (_i_h+1     == ${tile_dim_h})   ? ${x_tile_size_h_last} : ${x_tile_size_h};
 % if W_data_size_byte == 8 and 'Gemm' not in optional:
     x_tile_size_w   = (_i_w+1     == ${tile_dim_w})   ? ${(x_tile_size_w_last + 15) // 16 * 16} : ${(x_tile_size_w + 15) // 16 * 16};
@@ -114,7 +118,11 @@ int32_t ${func_name}(void* l2_x, void* l2_y)
     y_tile_size_w   = (_i_w+1     == ${tile_dim_w})   ? ${(y_tile_size_w_last)} : ${(y_tile_size_w)};
 % endif
     x_tile_size_byte = x_tile_size_nif*x_tile_size_h*x_tile_size_w*${x_data_size_byte}/8;
+% if 'Gemm' in optional:
     x_length_nif_byte = (_i_nif+1 == ${tile_dim_nif})   ? ${(x_tile_size_nif_byte_last + 15) // 16 * 16} : ${(x_tile_size_nif_byte + 15) // 16 * 16};
+% else:
+    x_length_nif_byte = (_i_nif+1 == ${tile_dim_nif})   ? ${x_tile_size_nif_byte_last} : ${x_tile_size_nif_byte};
+% endif
     y_tile_size_h   = (_i_h+1     == ${tile_dim_h})   ? ${y_tile_size_h_last} : ${y_tile_size_h};
 % if W_data_size_byte == 8:
     y_length_nof_byte = (_i_nof+1   == ${tile_dim_nof}) ? ${(W_tile_size_nof_last + 15) // 16 * 16} : ${(W_tile_size_nof + 15) // 16 * 16};


### PR DESCRIPTION
Input/output channels don't need to be multiple of 16 anymore.
Still need to fix this for depthwise convolutions.

For the width however, additional padding is needed -> WIP.

Changes were proposed by Amine and tested by myself.