### PR TITLE
Add initial_dir to network_run

### DIFF
--- a/dory/Hardware_targets/PULP/Common/Templates/main.c.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/main.c.t
@@ -64,6 +64,7 @@ void application(void * arg) {
 #endif
   size_t l2_input_size = ${int(DORY_HW_graph[0].tiling_dimensions["L2"]["input_activation_memory"])};
   size_t input_size = 1000000;
+  int initial_dir = 1;
   % if l3_supported:
 
   void *ram_input = ram_malloc(input_size);
@@ -79,7 +80,7 @@ void application(void * arg) {
   % if l3_supported:
       ram_read(l2_buffer, ram_input, l2_input_size);
   % endif
-      ${prefix}network_run(l2_buffer, ${l2_buffer_size}, l2_buffer, ${"0" if single_input else "exec"}${f", {prefix}L2_input_h{' + exec * l2_input_size' if not single_input else ''}" if not l3_supported else ""});
+      ${prefix}network_run(l2_buffer, ${l2_buffer_size}, l2_buffer, ${"0" if single_input else "exec"}, initial_dir${f", {prefix}L2_input_h{' + exec * l2_input_size' if not single_input else ''}" if not l3_supported else ""});
 
   % if not single_input:
   }

--- a/dory/Hardware_targets/PULP/Common/Templates/network.h.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.h.t
@@ -41,9 +41,9 @@ void ${prefix}network_terminate();
 void ${prefix}network_initialize();
 % endif
 void ${prefix}network_run_cluster(void * args);
-struct ${prefix}network_run_token ${prefix}network_run_async(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec${", void *L2_input_h" if not l3_supported else ""});
+struct ${prefix}network_run_token ${prefix}network_run_async(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec, int initial_dir${", void *L2_input_h" if not l3_supported else ""});
 void network_run_wait(struct ${prefix}network_run_token token);
-void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec${", void *L2_input_h" if not l3_supported else ""});
+void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec, int initial_dir${", void *L2_input_h" if not l3_supported else ""});
 void ${prefix}execute_layer_fork(void *arg);
 
 % if l3_supported and not single_input:


### PR DESCRIPTION
Add `initial_dir` to network_run so that we can have input on both sides of the allocated memory. Required for efficient input double buffering with the directional allocation scheme.