### PR TITLE
Refactor network functions

### DIFF
--- a/dory/Hardware_targets/PULP/Common/Templates/network.h.t
+++ b/dory/Hardware_targets/PULP/Common/Templates/network.h.t
@@ -31,20 +31,31 @@
 #include "pmsis.h"
 
 
-struct ${prefix}network_run_token {
+typedef struct ${prefix}network_t {
   struct pi_device cluster_dev;
-};
+  struct pi_cluster_task cluster_task;
+} ${prefix}network_t;
 
 
-% if l3_supported:
-void ${prefix}network_terminate();
-void ${prefix}network_initialize();
+typedef struct ${prefix}network_args_t {
+  void * l2_buffer;
+  size_t l2_buffer_size;
+  void * l2_final_output;
+  int32_t exec;
+  int32_t initial_allocator_dir;
+% if not l3_supported:
+  void * l2_input_h;
 % endif
+} ${prefix}network_args_t;
+
+
+void ${prefix}network_initialize(${prefix}network_t * network);
+void ${prefix}network_terminate(${prefix}network_t * network);
 void ${prefix}network_run_cluster(void * args);
-struct ${prefix}network_run_token ${prefix}network_run_async(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec, int initial_dir${", void *L2_input_h" if not l3_supported else ""});
-void network_run_wait(struct ${prefix}network_run_token token);
-void ${prefix}network_run(void *l2_buffer, size_t l2_buffer_size, void *l2_final_output, int exec, int initial_dir${", void *L2_input_h" if not l3_supported else ""});
-void ${prefix}execute_layer_fork(void *arg);
+void ${prefix}network_run_async(${prefix}network_t * network, ${prefix}network_args_t * args);
+void ${prefix}network_run_wait(${prefix}network_t * network);
+void ${prefix}network_run(${prefix}network_t * network, ${prefix}network_args_t * args);
+void ${prefix}execute_layer_fork(void * args);
 
 % if l3_supported and not single_input:
 static char * ${prefix}Input_names[${n_inputs}] = { \


### PR DESCRIPTION
While working on drone code, we noticed that there was redundant code in the network run function so I moved some code to the initializer.
Alongside that I aligned a little bit more the common and gap9 network templates in hopes to merge them completely soon.