### PR TITLE
setup.py: import setuptools so find_packages() resolves

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, Extension
+import setuptools
 import os
 
 


### PR DESCRIPTION
Fixes a NameError under modern pip/build isolation where setup.py
referenced setuptools.find_packages() without importing setuptools.
